### PR TITLE
Fix enemy collision box reset

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -57,8 +57,8 @@ export class Enemy {
     for (const collider of this.staticColliders) {
       if (this._bbox.intersectsBox(collider.box)) {
         this.mesh.position.copy(this._lastPos);
+        this._bbox.setFromCenterAndSize(this.mesh.position, this._bboxSize);
         this._pickDirection();
-        break;
       }
     }
 


### PR DESCRIPTION
## Summary
- Keep enemy bounding box in sync after collision resolution
- Continue checking all colliders so enemies can move away

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aacb2e032c832eb19c3566275382d3