### PR TITLE
Avoid enemy spawns inside static colliders

### DIFF
--- a/enemy.js
+++ b/enemy.js
@@ -1,6 +1,8 @@
 import { THREE } from './deps.js';
 import { PLAYFIELD_BOUNDS } from './level.js';
 
+export const ENEMY_SIZE_VECTOR = new THREE.Vector3(0.5, 0.5, 0.5);
+
 export class Enemy {
   constructor(scene, position = new THREE.Vector3(0, 0.25, 0), colliders = []) {
     this.scene = scene;
@@ -20,7 +22,7 @@ export class Enemy {
     this._velY = 0;
     this._falling = false;
     this._bbox = new THREE.Box3();
-    this._bboxSize = new THREE.Vector3(0.5, 0.5, 0.5);
+    this._bboxSize = ENEMY_SIZE_VECTOR;
     this._lastPos = this.mesh.position.clone();
     this._pickDirection();
   }

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ import { FOG, buildLevel } from './level.js';
 import { createPlayer } from './player.js';
 import { createCombat } from './combat.js';
 import { createHUD } from './hud.js';
-import { Enemy } from './enemy.js';
+import { Enemy, ENEMY_SIZE_VECTOR } from './enemy.js';
 import { initKeyboard, initOverlay, readXRInput, getInputState, settings } from './input.js';
 
 // Scene/Renderer
@@ -40,12 +40,21 @@ const combat = createCombat(scene, player, staticColliders, enemies);
 const hud = createHUD(player, combat);
 
 function spawnEnemy() {
-  const pos = new THREE.Vector3(
-    (Math.random() - 0.5) * 10,
-    0.25,
-    (Math.random() - 0.5) * 10
+  const pos = new THREE.Vector3();
+  const tmpBox = new THREE.Box3();
+  do {
+    pos.set(
+      (Math.random() - 0.5) * 10,
+      0.25,
+      (Math.random() - 0.5) * 10
+    );
+    tmpBox.setFromCenterAndSize(pos, ENEMY_SIZE_VECTOR);
+  } while (
+    staticColliders.some(
+      (c) => c.box.min.y !== c.box.max.y && tmpBox.intersectsBox(c.box)
+    )
   );
-  enemies.push(new Enemy(scene, pos, staticColliders));
+  enemies.push(new Enemy(scene, pos.clone(), staticColliders));
 }
 
 let enemySpawnTimer = 0;


### PR DESCRIPTION
## Summary
- export `ENEMY_SIZE_VECTOR` constant for unified enemy bounds
- ensure enemy spawn location avoids static colliders before spawning

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aacbf6ca3c832eb2b8ecd33f9eab00