### PR TITLE
Use CSS styling and XR support check for VR button

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,17 @@
     #crosshair::after { left:0; top:-10px; width:2px; height:20px; }
     #hudStats { position:absolute; top:12px; right:12px; text-align:right; }
     body.vr #hudStats { top:auto; bottom:12px; right:12px; }
+
+    /* VR button styling */
+    #internal-vrbutton {
+      display: inline-block !important;
+      position: static !important;
+      padding: 6px 10px !important;
+      border-radius: 8px !important;
+      border: 1px solid #444 !important;
+      background: #121212 !important;
+      color: #fff !important;
+    }
   </style>
 </head>
 <body>

--- a/input.js
+++ b/input.js
@@ -75,9 +75,13 @@ export function initOverlay(renderer, vrButtonEl, onSettingsChanged) {
   const btnStart = ov.querySelector('#btnStart');
   const vrMount = ov.querySelector('#vrMount');
 
-  if (vrButtonEl) {
-    vrMount.innerHTML = '';
-    vrMount.appendChild(vrButtonEl);
+  if (vrButtonEl && navigator.xr && navigator.xr.isSessionSupported) {
+    navigator.xr.isSessionSupported('immersive-vr').then((supported) => {
+      if (supported) {
+        vrMount.innerHTML = '';
+        vrMount.appendChild(vrButtonEl);
+      }
+    });
   }
 
   turnMode.value = settings.turnMode;

--- a/main.js
+++ b/main.js
@@ -65,13 +65,6 @@ initKeyboard();
 // VR-Button in Overlay mounten und Start-Callbacks verdrahten
 const vrBtn = VRButton.createButton(renderer);
 vrBtn.id = 'internal-vrbutton';
-vrBtn.style.display = 'inline-block';
-vrBtn.style.position = 'static';
-vrBtn.style.padding = '6px 10px';
-vrBtn.style.borderRadius = '8px';
-vrBtn.style.border = '1px solid #444';
-vrBtn.style.background = '#121212';
-vrBtn.style.color = '#fff';
 
 const { hideOverlay, onStartDesktop } = initOverlay(renderer, vrBtn, () => {
   // Wenn im Overlay die Hand gewechselt wird, sofort Gun umhängen


### PR DESCRIPTION
## Summary
- Move VR button styling from inline JavaScript to CSS via `#internal-vrbutton`
- Only mount VR button after confirming `navigator.xr.isSessionSupported('immersive-vr')`

## Testing
- `node --check main.js`
- `node --check input.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad03f18fc832e94ca4a75f1c30d6f