### PR TITLE
Fix player turn direction

### DIFF
--- a/player.js
+++ b/player.js
@@ -142,10 +142,10 @@ export function createPlayer(renderer) {
   function update(dt, input, colliders, walkables, turnMode, snapAngleDeg) {
     // Turning
     if (turnMode === 'smooth') {
-      playerYRotation -= input.turnAxis.x * 0.05;
+      playerYRotation += input.turnAxis.x * 0.05;
     } else {
       if (input.turnSnapDeltaRad) {
-        playerYRotation -= input.turnSnapDeltaRad;
+        playerYRotation += input.turnSnapDeltaRad;
       }
     }
 


### PR DESCRIPTION
## Summary
- Ensure right stick input rotates player clockwise in smooth turning
- Align snap turning direction with smooth turning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad1478714832e9e6d9c09634d3dd3